### PR TITLE
Updated brick/money dependencies requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,10 @@
     "name": "storekeeper/magento2-plugin",
     "description": "Storekeeper plugin",
     "require": {
-        "php": "^7.4|^8.1|^8.2",
+        "php": "^8.1|^8.2",
         "symfony/polyfill-uuid": "*",
         "magento/product-community-edition": "^2.4.5",
-        "brick/money": "0.5.*|0.6.*|0.7.*",
+        "brick/money": "0.9.*",
         "storekeeper/api-wrapper": "v5.2",
         "erusev/parsedown": "v1.7.4"
     },


### PR DESCRIPTION
 - Updated brick/money dependeincies
 - Updated php version dependencies (latest brick money works only with php 8)