### PR TITLE
Cu 86951qr16 non sk payments sync

### DIFF
--- a/Api/ApiClient.php
+++ b/Api/ApiClient.php
@@ -11,7 +11,7 @@ use StoreKeeper\StoreKeeper\Logger\Logger;
 
 class ApiClient
 {
-    private ScopeConfigInterface $scopeConfig;
+    protected ScopeConfigInterface $scopeConfig;
     protected Logger $logger;
     protected ?Auth $auth = null;
 

--- a/Api/PaymentApiClient.php
+++ b/Api/PaymentApiClient.php
@@ -2,12 +2,14 @@
 
 namespace StoreKeeper\StoreKeeper\Api;
 
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Sales\Api\Data\OrderInterface;
 use StoreKeeper\ApiWrapper\ModuleApiWrapper;
 use StoreKeeper\StoreKeeper\Api\ApiClient;
 use StoreKeeper\StoreKeeper\Api\OrderApiClient;
 use StoreKeeper\ApiWrapper\ModuleApiWrapperInterface;
 use StoreKeeper\ApiWrapper\Exception\GeneralException;
+use StoreKeeper\StoreKeeper\Logger\Logger;
 
 class PaymentApiClient extends ApiClient
 {
@@ -20,8 +22,11 @@ class PaymentApiClient extends ApiClient
      * @param OrderApiClient $orderApiClient
      */
     public function __construct(
+        ScopeConfigInterface $scopeConfig,
+        Logger $logger,
         OrderApiClient $orderApiClient
     ) {
+        parent::__construct($scopeConfig, $logger);
         $this->orderApiClient = $orderApiClient;
     }
 
@@ -41,7 +46,7 @@ class PaymentApiClient extends ApiClient
      * @return int
      * @throws \Exception
      */
-    public function getNewWebPayment(string $storeId, array $parameters = []): int
+    public function newWebPayment(string $storeId, array $parameters = []): int
     {
         return $this->getPaymentModule($storeId)->newWebPayment($parameters);
     }
@@ -133,6 +138,19 @@ class PaymentApiClient extends ApiClient
                     'products' => $products,
                 ]
             );
+        }
+    }
+
+    /**
+     * @param string $paymentMethodCode
+     * @return bool
+     */
+    public function isStorekeeperPayment(string $paymentMethodCode)
+    {
+        if (is_int(strpos($paymentMethodCode, 'storekeeper'))) {
+            return true;
+        } else {
+            return false;
         }
     }
 

--- a/Api/Webhook/Webhook.php
+++ b/Api/Webhook/Webhook.php
@@ -40,7 +40,6 @@ class Webhook
      * @param PublisherInterface $publisher
      * @param Config $configHelper
      * @param Logger $logger
-     * @param TimezoneInterface $timezone
      * @param JsonResponse $jsonResponse
      * @param EventLogInterfaceFactory $eventLogFactory
      * @param EventLogRepository $eventLogRepository
@@ -54,7 +53,6 @@ class Webhook
         PublisherInterface $publisher,
         Config $configHelper,
         Logger $logger,
-        TimezoneInterface $timezone,
         JsonResponse $jsonResponse,
         EventLogInterfaceFactory $eventLogFactory,
         EventLogRepository $eventLogRepository,

--- a/Api/Webhook/Webhook.php
+++ b/Api/Webhook/Webhook.php
@@ -283,13 +283,14 @@ class Webhook
     private function addEventLog(string $action, string $status): void
     {
         $eventLog = $this->eventLogFactory->create();
+        $time = $this->timezone->date(new \DateTime());
         $eventLog->addData([
             'request_route' => $this->request->getPathInfo(),
             'request_body' => $this->request->getContent(),
             'request_method' => $this->request->getMethod(),
             'request_action' => $action,
             'response_code' => $status,
-            'date' => $this->timezone->date()->getTimestamp()
+            'date' => $time->format('Y-m-d H:i:s')
         ]);
 
         $this->eventLogRepository->save($eventLog);

--- a/Helper/Api/Orders.php
+++ b/Helper/Api/Orders.php
@@ -263,7 +263,7 @@ class Orders extends AbstractHelper
             // 90             - 70                 = 20
             // in this above example we'll have to refund 20
             if ($diff > 0) {
-                $storekeeperRefundId = $this->paymentApiClient->getNewWebPayment(
+                $storekeeperRefundId = $this->paymentApiClient->newWebPayment(
                     $order->getStoreId(),
                     [
                         'amount' => round(-abs($diff), 2),

--- a/Observers/SalesOrderInvoicePayObserver.php
+++ b/Observers/SalesOrderInvoicePayObserver.php
@@ -5,6 +5,7 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\MessageQueue\PublisherInterface;
 use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Sales\Model\ResourceModel\Order as OrderResource;
 use StoreKeeper\StoreKeeper\Api\PaymentApiClient;
 use StoreKeeper\StoreKeeper\Helper\Api\Auth;
 
@@ -14,6 +15,7 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
     private Json $json;
     private PublisherInterface $publisher;
     private PaymentApiClient $paymentApiClient;
+    private OrderResource $orderResource;
 
     /**
      * Constructor
@@ -22,17 +24,20 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
      * @param Json $json
      * @param PublisherInterface $publisher
      * @param PaymentApiClient $paymentApiClient
+     * @param OrderResource $orderResource
      */
     public function __construct(
         Auth $authHelper,
         Json $json,
         PublisherInterface $publisher,
-        PaymentApiClient $paymentApiClient
+        PaymentApiClient $paymentApiClient,
+        OrderResource $orderResource
     ) {
         $this->authHelper = $authHelper;
         $this->json = $json;
         $this->publisher = $publisher;
         $this->paymentApiClient = $paymentApiClient;
+        $this->orderResource = $orderResource;
     }
 
     /**
@@ -69,6 +74,9 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
                         $storekeeperPaymentId
                     ]
                 );
+
+                $order->setData('storekeeper_payment_id', $payment['id']);
+                $this->orderResource->saveAttribute($order, 'storekeeper_payment_id');
             }
         }
     }

--- a/Observers/SalesOrderInvoicePayObserver.php
+++ b/Observers/SalesOrderInvoicePayObserver.php
@@ -57,7 +57,6 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
                 && !$this->paymentApiClient->isStorekeeperPayment($order->getPayment()->getMethod())
                 && $this->authHelper->isOrderSyncEnabled($order->getStoreId())
                 && !$order->getOrderDetached()
-                && $storekeeperId
             ) {
                 $storekeeperPaymentId = $this->paymentApiClient->newWebPayment(
                     $order->getStoreId(),
@@ -67,13 +66,15 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
                     ]
                 );
 
-                $this->paymentApiClient->attachPaymentIdsToOrder(
-                    $order->getStoreId(),
-                    $storekeeperId,
-                    [
-                        $storekeeperPaymentId
-                    ]
-                );
+                if ($storekeeperId) {
+                    $this->paymentApiClient->attachPaymentIdsToOrder(
+                        $order->getStoreId(),
+                        $storekeeperId,
+                        [
+                            $storekeeperPaymentId
+                        ]
+                    );
+                }
 
                 $order->setData('storekeeper_payment_id', $storekeeperPaymentId);
                 $this->orderResource->saveAttribute($order, 'storekeeper_payment_id');

--- a/Plugin/Magento/MysqlMq/Model/ResourceModel/Queue.php
+++ b/Plugin/Magento/MysqlMq/Model/ResourceModel/Queue.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace StoreKeeper\StoreKeeper\Plugin\Magento\MysqlMq\Model\ResourceModel;
 
-use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 use Magento\MysqlMq\Model\ResourceModel\Queue as subjectQueue;
 use Magento\MysqlMq\Model\ResourceModel\MessageCollectionFactory;
 use Magento\MysqlMq\Model\ResourceModel\MessageStatusCollectionFactory;
@@ -26,7 +25,6 @@ class Queue
     private MessageStatusCollectionFactory $messageStatusCollectionFactory;
     private TaskLogRepositoryInterface $taskLogRepository;
     private TaskLogInterfaceFactory $taskLogFactory;
-    private TimezoneInterface $timezone;
 
     /**
      * Constructor
@@ -35,20 +33,17 @@ class Queue
      * @param MessageStatusCollectionFactory $messageStatusCollectionFactory
      * @param TaskLogInterfaceFactory $taskLogFactory
      * @param TaskLogRepositoryInterface $taskLogRepository
-     * @param TimezoneInterface $timezone
      */
     public function __construct (
         MessageCollectionFactory $messageCollectionFactory,
         MessageStatusCollectionFactory $messageStatusCollectionFactory,
         TaskLogInterfaceFactory $taskLogFactory,
-        TaskLogRepositoryInterface $taskLogRepository,
-        TimezoneInterface $timezone
+        TaskLogRepositoryInterface $taskLogRepository
     ) {
         $this->messageCollectionFactory = $messageCollectionFactory;
         $this->messageStatusCollectionFactory = $messageStatusCollectionFactory;
         $this->taskLogFactory = $taskLogFactory;
         $this->taskLogRepository = $taskLogRepository;
-        $this->timezone = $timezone;
     }
 
     /**
@@ -71,8 +66,7 @@ class Queue
                         $taskLog = $this->taskLogFactory->create();
                         $taskLog->addData($message->getData());
                         $taskLog->setMessageId($message->getId());
-                        $time = $this->timezone->date(new \DateTime($message->getUpdatedAt()));
-                        $taskLog->setUpdatedAt($time->format('Y-m-d H:i:s'));
+                        $taskLog->setUpdatedAt($this->dateTime->gmtDate());
 
                         $this->taskLogRepository->save($taskLog);
                     }
@@ -130,8 +124,7 @@ class Queue
                 $taskLog = $this->taskLogRepository->getByMessageId($messageId);
                 $taskLog->setTopicName($message->getTopicName());
                 $taskLog->setBody($message->getBody());
-                $time = $this->timezone->date(new \DateTime($message->getUpdatedAt()));
-                $taskLog->setUpdatedAt($time->format('Y-m-d H:i:s'));
+                $taskLog->setUpdatedAt($this->dateTime->gmtDate());
                 $taskLog->setStatus($message->getStatus());
                 $taskLog->setNumberOfTrials($message->getNumberOfTrials());
 

--- a/Plugin/Magento/MysqlMq/Model/ResourceModel/Queue.php
+++ b/Plugin/Magento/MysqlMq/Model/ResourceModel/Queue.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace StoreKeeper\StoreKeeper\Plugin\Magento\MysqlMq\Model\ResourceModel;
 
+use Magento\Framework\Stdlib\DateTime\DateTime;
 use Magento\MysqlMq\Model\ResourceModel\Queue as subjectQueue;
 use Magento\MysqlMq\Model\ResourceModel\MessageCollectionFactory;
 use Magento\MysqlMq\Model\ResourceModel\MessageStatusCollectionFactory;
@@ -25,6 +26,7 @@ class Queue
     private MessageStatusCollectionFactory $messageStatusCollectionFactory;
     private TaskLogRepositoryInterface $taskLogRepository;
     private TaskLogInterfaceFactory $taskLogFactory;
+    private DateTime $dateTime;
 
     /**
      * Constructor
@@ -33,17 +35,20 @@ class Queue
      * @param MessageStatusCollectionFactory $messageStatusCollectionFactory
      * @param TaskLogInterfaceFactory $taskLogFactory
      * @param TaskLogRepositoryInterface $taskLogRepository
+     * @param DateTime $dateTime
      */
     public function __construct (
         MessageCollectionFactory $messageCollectionFactory,
         MessageStatusCollectionFactory $messageStatusCollectionFactory,
         TaskLogInterfaceFactory $taskLogFactory,
-        TaskLogRepositoryInterface $taskLogRepository
+        TaskLogRepositoryInterface $taskLogRepository,
+        DateTime $dateTime
     ) {
         $this->messageCollectionFactory = $messageCollectionFactory;
         $this->messageStatusCollectionFactory = $messageStatusCollectionFactory;
         $this->taskLogFactory = $taskLogFactory;
         $this->taskLogRepository = $taskLogRepository;
+        $this->dateTime = $dateTime;
     }
 
     /**

--- a/Plugin/Magento/MysqlMq/Model/ResourceModel/Queue.php
+++ b/Plugin/Magento/MysqlMq/Model/ResourceModel/Queue.php
@@ -71,7 +71,8 @@ class Queue
                         $taskLog = $this->taskLogFactory->create();
                         $taskLog->addData($message->getData());
                         $taskLog->setMessageId($message->getId());
-                        $taskLog->setUpdatedAt($this->timezone->date($message->getUpdatedAt())->getTimestamp());
+                        $time = $this->timezone->date(new \DateTime($message->getUpdatedAt()));
+                        $taskLog->setUpdatedAt($time->format('Y-m-d H:i:s'));
 
                         $this->taskLogRepository->save($taskLog);
                     }
@@ -129,7 +130,8 @@ class Queue
                 $taskLog = $this->taskLogRepository->getByMessageId($messageId);
                 $taskLog->setTopicName($message->getTopicName());
                 $taskLog->setBody($message->getBody());
-                $taskLog->setUpdatedAt($this->timezone->date($message->getUpdatedAt())->getTimestamp());
+                $time = $this->timezone->date(new \DateTime($message->getUpdatedAt()));
+                $taskLog->setUpdatedAt($time->format('Y-m-d H:i:s'));
                 $taskLog->setStatus($message->getStatus());
                 $taskLog->setNumberOfTrials($message->getNumberOfTrials());
 

--- a/Test/Integration/AbstractTestCase.php
+++ b/Test/Integration/AbstractTestCase.php
@@ -175,7 +175,7 @@ abstract class AbstractTestCase extends TestCase
             ->willReturn([
                 'status' => 'paid'
             ]);
-        $this->paymentApiClientMock->method('getNewWebPayment')
+        $this->paymentApiClientMock->method('newWebPayment')
             ->willReturn(33);
 
         $this->apiOrders = $objectManager->getObject(

--- a/Test/Integration/Mock/InvoiceObserverMock.php
+++ b/Test/Integration/Mock/InvoiceObserverMock.php
@@ -1,0 +1,13 @@
+<?php
+namespace StoreKeeper\StoreKeeper\Test\Integration\Mock;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class InvoiceObserverMock implements ObserverInterface
+{
+    public function execute(Observer $observer)
+    {
+        // Dummy data for disabling original observer
+    }
+}

--- a/Test/Integration/WebhookTest.php
+++ b/Test/Integration/WebhookTest.php
@@ -99,7 +99,7 @@ class WebhookTest extends AbstractTestCase
 
         $ex = new GeneralException('The new refund has not to be created', 0);
         $ex->setApiExceptionClass('ShopModule::GeneralException');
-        $this->paymentApiClientMock->method('getNewWebPayment')->willThrowException($ex);
+        $this->paymentApiClientMock->method('newWebPayment')->willThrowException($ex);
     }
 
     /**

--- a/view/adminhtml/ui_component/storekeeper_storekeeper_eventlog_listing.xml
+++ b/view/adminhtml/ui_component/storekeeper_storekeeper_eventlog_listing.xml
@@ -78,11 +78,12 @@
 				<label translate="true">Response Code</label>
 			</settings>
 		</column>
-		<column name="date">
-			<settings>
-				<filter>text</filter>
-				<label translate="true">Date</label>
-			</settings>
-		</column>
+        <column name="date" class="Magento\Ui\Component\Listing\Columns\Date" component="Magento_Ui/js/grid/columns/date">
+            <settings>
+                <filter>dateRange</filter>
+                <dataType>date</dataType>
+                <label translate="true">Date</label>
+            </settings>
+        </column>
 	</columns>
 </listing>


### PR DESCRIPTION
 - Implemented invoice sync for non-SK payment methods via  'sales_order_invoice_pay' observer event. Renamed api-wrapper method from 'getNewWebPayment' to 'newWebPayment';
 - Created integration test for payment and invoice creation;
 - Updated time format for task and event log admin grids.