### PR TITLE
Cu 86957jq90 Product export: handle description field content during export and import

### DIFF
--- a/Helper/Api/Products.php
+++ b/Helper/Api/Products.php
@@ -34,6 +34,7 @@ use StoreKeeper\StoreKeeper\Logger\Logger;
 use StoreKeeper\StoreKeeper\Api\ProductApiClient;
 use StoreKeeper\StoreKeeper\Api\OrderApiClient;
 use StoreKeeper\StoreKeeper\Helper\Config;
+use StoreKeeper\StoreKeeper\Model\Export\ProductExportManager;
 use Magento\InventoryCatalogApi\Model\SourceItemsProcessorInterface;
 
 /**
@@ -993,9 +994,12 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
         }
 
         $parseDown = new Parsedown();
+        $parseDown->setSafeMode(true);
 
         $newDescription = $parseDown->text($body);
-        if ($target->getDescription() != $newDescription) {
+        if (
+            $target->getDescription() != $newDescription && !$this->isDisallowedContentExist($target->getDescription())
+        ) {
             $shouldUpdate = true;
             $target->setDescription($newDescription);
         }
@@ -1222,5 +1226,16 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
         }
 
         return $configurableAttributesData;
+    }
+
+    private function isDisallowedContentExist(string $description): bool
+    {
+        foreach (ProductExportManager::DISALLOWED_CONTENT as $pattern) {
+            if (preg_match($pattern, $description)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/Helper/Api/Products.php
+++ b/Helper/Api/Products.php
@@ -34,6 +34,7 @@ use StoreKeeper\StoreKeeper\Logger\Logger;
 use StoreKeeper\StoreKeeper\Api\ProductApiClient;
 use StoreKeeper\StoreKeeper\Api\OrderApiClient;
 use StoreKeeper\StoreKeeper\Helper\Config;
+use StoreKeeper\StoreKeeper\Helper\ProductDescription as ProductDescriptionHelper;
 use StoreKeeper\StoreKeeper\Model\Export\ProductExportManager;
 use Magento\InventoryCatalogApi\Model\SourceItemsProcessorInterface;
 
@@ -72,6 +73,7 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
     private ConfigurableResourceModel $configurableResourceModel;
     private Configurable $configurable;
     private OptionsFactory $optionsFactory;
+    private ProductDescriptionHelper $productDescription;
     private array $_simpleProductIds = [];
 
     /**
@@ -105,6 +107,7 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
      * @param ConfigurableResourceModel $configurableResourceModel
      * @param Configurable $configurable
      * @param OptionsFactory $optionsFactory
+     * @param ProductDescriptionHelper $productDescription
      */
     public function __construct(
         Auth $authHelper,
@@ -134,7 +137,8 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
         OptionFactory $optionFactory,
         ConfigurableResourceModel $configurableResourceModel,
         Configurable $configurable,
-        OptionsFactory $optionsFactory
+        OptionsFactory $optionsFactory,
+        ProductDescriptionHelper $productDescription
     ) {
         $this->authHelper = $authHelper;
         $this->productFactory = $productFactory;
@@ -163,6 +167,7 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
         $this->configurableResourceModel = $configurableResourceModel;
         $this->configurable = $configurable;
         $this->optionsFactory = $optionsFactory;
+        $this->productDescription = $productDescription;
     }
 
     /**
@@ -998,7 +1003,8 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
 
         $newDescription = $parseDown->text($body);
         if (
-            $target->getDescription() != $newDescription && !$this->isDisallowedContentExist($target->getDescription())
+            $target->getDescription() != $newDescription
+            && !$this->productDescription->isDisallowedContentExist($target->getDescription())
         ) {
             $shouldUpdate = true;
             $target->setDescription($newDescription);
@@ -1226,16 +1232,5 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
         }
 
         return $configurableAttributesData;
-    }
-
-    private function isDisallowedContentExist(string $description): bool
-    {
-        foreach (ProductExportManager::DISALLOWED_CONTENT as $pattern) {
-            if (preg_match($pattern, $description)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/Helper/ProductDescription.php
+++ b/Helper/ProductDescription.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace StoreKeeper\StoreKeeper\Helper;
+
+class ProductDescription
+{
+    const DISALLOWED_CONTENT = [
+        '/<style\b[^>]*>([\s\S]*?)<\/style>/i',
+        '/<figure\s+data-content-type="image"[^>]*>[\s\S]*?<\/figure>/i',
+        '/{{widget[^}]*}}/i'
+    ];
+
+    /**
+     * @param string $description
+     * @return string
+     */
+    public function formatProductDescription(string $description): string
+    {
+        foreach (self::DISALLOWED_CONTENT as $pattern) {
+            if (preg_match($pattern, $description)) {
+                $description = preg_replace($pattern, '', $description);
+            }
+        }
+
+        return $description;
+    }
+
+    /**
+     * @param string $description
+     * @return bool
+     */
+    public function isDisallowedContentExist(string $description): bool
+    {
+        foreach (self::DISALLOWED_CONTENT as $pattern) {
+            if (preg_match($pattern, $description)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Model/Export/CategoryExportManager.php
+++ b/Model/Export/CategoryExportManager.php
@@ -85,7 +85,7 @@ class CategoryExportManager extends AbstractExportManager
                 $category->getMetaKeywords(), //'path://seo_keywords'
                 $category->getMetaDescription(), //'path://seo_description'
                 $category->getImageUrl(), //'path://image_url'
-                null, //'path://published'
+                1, //'path://published'
                 $category->getPosition(), //'path://order'
                 $this->getCategoryParentUrl($category), //'path://parent_slug'
                 null, //'path://protected'

--- a/Test/Integration/Export/CategoryExportDataTest.php
+++ b/Test/Integration/Export/CategoryExportDataTest.php
@@ -70,7 +70,7 @@ class CategoryExportDataTest extends AbstractTestCase
                 . ltrim(FileInfo::ENTITY_MEDIA_PATH, '/')
                 . '/'
                 . 'magento_small_image.jpg',
-            'path://published' => NULL,
+            'path://published' => 1,
             'path://order' => '1',
             'path://parent_slug' => null,
             'path://protected' => NULL

--- a/Test/Integration/Export/ProductExportDataTest.php
+++ b/Test/Integration/Export/ProductExportDataTest.php
@@ -78,7 +78,7 @@ class ProductExportDataTest extends AbstractTestCase
             'path://product.active' => 'yes',
             'path://product.product_stock.in_stock' => 'yes',
             'path://product.product_stock.value' => 100,
-            'path://product.product_stock.unlimited' => 'yes',
+            'path://product.product_stock.unlimited' => 'no',
             'path://shop_products.main.backorder_enabled' => 'no',
             'path://product.product_price.tax' => 0.21,
             'path://product.product_price.tax_rate.country_iso2' => 'NL',

--- a/Test/Integration/ProductDescriptionTest.php
+++ b/Test/Integration/ProductDescriptionTest.php
@@ -14,22 +14,33 @@ class ProductDescriptionTest extends TestCase
 <p><span style="font-size: 24px;"><strong>Montage richting terugslagklep?</strong></span></p>
 <div><br><span style="font-size: 24px;">Duis ac metus placerat, mollis lorem sed, congue ligula. Maecenas blandit tellus id mi interdum, ultrices condimentum felis interdum.&nbsp;</span></div></div><figure data-content-type="image" data-appearance="full-width" data-element="main" data-pb-style="BMP4ECP"><img class="pagebuilder-mobile-hidden" src="{{media url=wysiwyg/redi_terugslagklep_tekening_1.jpg}}" alt="" title="" data-element="desktop_image" data-pb-style="GB01A2F"><img class="pagebuilder-mobile-only" src="{{media url=wysiwyg/redi_terugslagklep_tekening_1.jpg}}" alt="" title="" data-element="mobile_image" data-pb-style="P7UX7MQ"></figure><div data-content-type="divider" data-appearance="default" data-element="main"><hr data-element="line" data-pb-style="C4Q63GI"></div><div data-content-type="text" data-appearance="default" data-element="main"><p><strong><span style="font-size: 20px;">Mauris rhoncus sem non viverra tincidunt.</span></strong></p></div><div data-content-type="products" data-appearance="grid" data-element="main">{{widget type="Magento\CatalogWidget\Block\Product\ProductsList" template="Magento_CatalogWidget::product/widget/content/grid.phtml" anchor_text="" id_path="" show_pager="0" products_count="5" condition_option="sku" condition_option_value="8716936000381,8715598200214,8715598100309,8716936026725,8712603121649" type_name="Catalog Products List" conditions_encoded="^[`1`:^[`aggregator`:`all`,`new_child`:``,`type`:`Magento||CatalogWidget||Model||Rule||Condition||Combine`,`value`:`1`^],`1--1`:^[`operator`:`()`,`type`:`Magento||CatalogWidget||Model||Rule||Condition||Product`,`attribute`:`sku`,`value`:`8716936000381,8715598200214,8715598100309,8716936026725,8712603121649`^]^]" sort_order="position_by_sku"}}</div></div></div>';
 
-    const EXPECTED_DESCRIPTION = '';
+    const EXPECTED_DESCRIPTION = '<div data-content-type="row" data-appearance="contained" data-element="main"><div data-enable-parallax="0" data-parallax-speed="0.5" data-background-images="{}" data-background-type="image" data-video-loop="true" data-video-play-only-visible="true" data-video-lazy-load="true" data-video-fallback-src="" data-element="inner" data-pb-style="IQ4798T"><div data-content-type="text" data-appearance="default" data-element="main"><p><strong><span style="font-size: 24px;">Lorem Ipsum</span></strong></p>
+<div><br><span style="font-size: 24px;">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur bibendum auctor turpis vel egestas. Nulla porttitor ac mi eget malesuada. Donec varius est tincidunt tellus venenatis, in rutrum leo tempor. Duis iaculis suscipit turpis sit amet molestie. Ut iaculis tincidunt placerat. Nulla finibus risus dui, ut sodales velit suscipit id. Cras urna libero, sodales in dolor sed, tempor euismod mauris.</span></div>
+<div><span style="font-size: 24px;">Vivamus vulputate magna tincidunt urna gravida, in congue nisi molestie.</span></div>
+<p>&nbsp;</p>
+<p><span style="font-size: 24px;"><strong>Montage richting terugslagklep?</strong></span></p>
+<div><br><span style="font-size: 24px;">Duis ac metus placerat, mollis lorem sed, congue ligula. Maecenas blandit tellus id mi interdum, ultrices condimentum felis interdum.&nbsp;</span></div></div><div data-content-type="divider" data-appearance="default" data-element="main"><hr data-element="line" data-pb-style="C4Q63GI"></div><div data-content-type="text" data-appearance="default" data-element="main"><p><strong><span style="font-size: 20px;">Mauris rhoncus sem non viverra tincidunt.</span></strong></p></div><div data-content-type="products" data-appearance="grid" data-element="main"></div></div></div>';
 
-    protected $produdtDescription;
+    protected $productDescription;
 
     protected function setUp(): void
     {
-        $this->produdtDescription = Bootstrap::getObjectManager()->create(\StoreKeeper\StoreKeeper\Helper\ProductDescription::class);
+        $this->productDescription = Bootstrap::getObjectManager()->create(\StoreKeeper\StoreKeeper\Helper\ProductDescription::class);
     }
 
     public function testFormatProductDescription()
     {
-        $actualDescription = $produdtDescription->formatProductDescription(self::EXPECTED_DESCRIPTION);
+        $actualDescription = $this->productDescription->formatProductDescription(self::FULL_DESCRIPTION);
+
+        //assert of trimmed description
+        $this->assertEquals(self::EXPECTED_DESCRIPTION, $actualDescription);
     }
 
     public function testIsDisallowedContentExist()
     {
-        $result = $this->produdtDescription->isDisallowedContent(self::EXPECTED_DESCRIPTION);
+        $result = $this->productDescription->isDisallowedContentExist(self::FULL_DESCRIPTION);
+
+        //Assert that provided description has disallowed content
+        $this->assertTrue($result);
     }
 }

--- a/Test/Integration/ProductDescriptionTest.php
+++ b/Test/Integration/ProductDescriptionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace StoreKeeper\StoreKeeper\Test\Integration;
+
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+class ProductDescriptionTest extends TestCase
+{
+    const FULL_DESCRIPTION = '<style>#html-body [data-pb-style=IQ4798T]{justify-content:flex-start;display:flex;flex-direction:column;background-position:left top;background-size:cover;background-repeat:no-repeat;background-attachment:scroll}#html-body [data-pb-style=BMP4ECP]{border-style:none}#html-body [data-pb-style=GB01A2F],#html-body [data-pb-style=P7UX7MQ]{max-width:100%;height:auto}#html-body [data-pb-style=C4Q63GI]{width:100%;border-width:1px;border-color:#cecece;display:inline-block}@media only screen and (max-width: 768px) { #html-body [data-pb-style=BMP4ECP]{border-style:none} }</style><div data-content-type="row" data-appearance="contained" data-element="main"><div data-enable-parallax="0" data-parallax-speed="0.5" data-background-images="{}" data-background-type="image" data-video-loop="true" data-video-play-only-visible="true" data-video-lazy-load="true" data-video-fallback-src="" data-element="inner" data-pb-style="IQ4798T"><div data-content-type="text" data-appearance="default" data-element="main"><p><strong><span style="font-size: 24px;">Lorem Ipsum</span></strong></p>
+<div><br><span style="font-size: 24px;">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur bibendum auctor turpis vel egestas. Nulla porttitor ac mi eget malesuada. Donec varius est tincidunt tellus venenatis, in rutrum leo tempor. Duis iaculis suscipit turpis sit amet molestie. Ut iaculis tincidunt placerat. Nulla finibus risus dui, ut sodales velit suscipit id. Cras urna libero, sodales in dolor sed, tempor euismod mauris.</span></div>
+<div><span style="font-size: 24px;">Vivamus vulputate magna tincidunt urna gravida, in congue nisi molestie.</span></div>
+<p>&nbsp;</p>
+<p><span style="font-size: 24px;"><strong>Montage richting terugslagklep?</strong></span></p>
+<div><br><span style="font-size: 24px;">Duis ac metus placerat, mollis lorem sed, congue ligula. Maecenas blandit tellus id mi interdum, ultrices condimentum felis interdum.&nbsp;</span></div></div><figure data-content-type="image" data-appearance="full-width" data-element="main" data-pb-style="BMP4ECP"><img class="pagebuilder-mobile-hidden" src="{{media url=wysiwyg/redi_terugslagklep_tekening_1.jpg}}" alt="" title="" data-element="desktop_image" data-pb-style="GB01A2F"><img class="pagebuilder-mobile-only" src="{{media url=wysiwyg/redi_terugslagklep_tekening_1.jpg}}" alt="" title="" data-element="mobile_image" data-pb-style="P7UX7MQ"></figure><div data-content-type="divider" data-appearance="default" data-element="main"><hr data-element="line" data-pb-style="C4Q63GI"></div><div data-content-type="text" data-appearance="default" data-element="main"><p><strong><span style="font-size: 20px;">Mauris rhoncus sem non viverra tincidunt.</span></strong></p></div><div data-content-type="products" data-appearance="grid" data-element="main">{{widget type="Magento\CatalogWidget\Block\Product\ProductsList" template="Magento_CatalogWidget::product/widget/content/grid.phtml" anchor_text="" id_path="" show_pager="0" products_count="5" condition_option="sku" condition_option_value="8716936000381,8715598200214,8715598100309,8716936026725,8712603121649" type_name="Catalog Products List" conditions_encoded="^[`1`:^[`aggregator`:`all`,`new_child`:``,`type`:`Magento||CatalogWidget||Model||Rule||Condition||Combine`,`value`:`1`^],`1--1`:^[`operator`:`()`,`type`:`Magento||CatalogWidget||Model||Rule||Condition||Product`,`attribute`:`sku`,`value`:`8716936000381,8715598200214,8715598100309,8716936026725,8712603121649`^]^]" sort_order="position_by_sku"}}</div></div></div>';
+
+    const EXPECTED_DESCRIPTION = '';
+
+    protected $produdtDescription;
+
+    protected function setUp(): void
+    {
+        $this->produdtDescription = Bootstrap::getObjectManager()->create(\StoreKeeper\StoreKeeper\Helper\ProductDescription::class);
+    }
+
+    public function testFormatProductDescription()
+    {
+        $actualDescription = $produdtDescription->formatProductDescription(self::EXPECTED_DESCRIPTION);
+    }
+
+    public function testIsDisallowedContentExist()
+    {
+        $result = $this->produdtDescription->isDisallowedContent(self::EXPECTED_DESCRIPTION);
+    }
+}


### PR DESCRIPTION
 - Implemented logic which trims tags not supported on sk backend. Set published field for categories to forced '1', set product.product_stock.unlimited to forced 'no';
 - Updated product and category export integration test according to changes in published and manage stock expected values