### PR TITLE
Cu 86958xq6c category export ignore unsupported images

### DIFF
--- a/Model/Export/CategoryExportManager.php
+++ b/Model/Export/CategoryExportManager.php
@@ -3,11 +3,13 @@
 namespace StoreKeeper\StoreKeeper\Model\Export;
 
 use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Framework\Filesystem\DirectoryList;
 use Magento\Framework\Locale\Resolver;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Catalog\Api\CategoryRepositoryInterface;
 use Magento\Store\Api\StoreConfigManagerInterface;
 use StoreKeeper\StoreKeeper\Helper\Api\Auth;
+use StoreKeeper\StoreKeeper\Model\Export\ProductExportManager;
 
 class CategoryExportManager extends AbstractExportManager
 {
@@ -50,18 +52,35 @@ class CategoryExportManager extends AbstractExportManager
     private CategoryRepositoryInterface $categoryRepository;
     private StoreManagerInterface $storeManager;
     private Auth $authHelper;
+    private ProductExportManager $productExportManager;
     private $_defaultCategory;
+    private DirectoryList $directoryList;
 
+    /**
+     * Constructor
+     *
+     * @param Resolver $localeResolver
+     * @param StoreManagerInterface $storeManager
+     * @param CategoryRepositoryInterface $categoryRepository
+     * @param StoreConfigManagerInterface $storeConfigManager
+     * @param Auth $authHelper
+     * @param \StoreKeeper\StoreKeeper\Model\Export\ProductExportManager $productExportManager
+     * @param DirectoryList $directoryList
+     */
     public function __construct(
         Resolver $localeResolver,
         StoreManagerInterface $storeManager,
         CategoryRepositoryInterface $categoryRepository,
         StoreConfigManagerInterface $storeConfigManager,
-        Auth $authHelper
+        Auth $authHelper,
+        ProductExportManager $productExportManager,
+        DirectoryList $directoryList
     ) {
         parent::__construct($localeResolver, $storeManager, $storeConfigManager, $authHelper);
         $this->storeManager = $storeManager;
         $this->categoryRepository = $categoryRepository;
+        $this->productExportManager = $productExportManager;
+        $this->directoryList = $directoryList;
     }
 
     /**
@@ -80,6 +99,8 @@ class CategoryExportManager extends AbstractExportManager
                 continue;
             }
 
+            $categoryImage = $this->getCategoryImageUrl($category->getImageUrl());
+
             $data = [
                 $categoryName, //'path://title'
                 $currentLocale, //'path://translatable.lang'
@@ -91,7 +112,7 @@ class CategoryExportManager extends AbstractExportManager
                 $category->getMetaTitle(), //'path://seo_title'
                 $category->getMetaKeywords(), //'path://seo_keywords'
                 $category->getMetaDescription(), //'path://seo_description'
-                $category->getImageUrl(), //'path://image_url'
+                $categoryImage, //'path://image_url'
                 1, //'path://published'
                 $category->getPosition(), //'path://order'
                 $this->getCategoryParentUrl($category), //'path://parent_slug'
@@ -132,5 +153,27 @@ class CategoryExportManager extends AbstractExportManager
         }
 
         return $this->_defaultCategory;
+    }
+
+    /**
+     * @param string|null $image
+     * @return string|null
+     * @throws \Magento\Framework\Exception\FileSystemException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    private function getCategoryImageUrl(?string $image): ?string
+    {
+        $imageUrl = null;
+
+        if ($image) {
+            $mediaBaseDir = $this->directoryList->getPath(\Magento\Framework\App\Filesystem\DirectoryList::PUB);
+            $imagePath = $mediaBaseDir . $image;
+            if ($this->productExportManager->isImageFormatAllowed($imagePath)) {
+                $mediaUrl = $this->storeManager->getStore()->getBaseUrl();
+                $imageUrl = rtrim($mediaUrl, '/') . $image;
+            }
+        }
+
+        return $imageUrl;
     }
 }

--- a/Model/Export/ProductExportManager.php
+++ b/Model/Export/ProductExportManager.php
@@ -608,7 +608,11 @@ class ProductExportManager extends AbstractExportManager
      */
     public function isImageFormatAllowed(?string $url): bool
     {
-        $imageType = $this->fileinfoMimeTypeGuesser->guessMimeType($url);
+        try {
+            $imageType = $this->fileinfoMimeTypeGuesser->guessMimeType($url);
+        } catch (\Exception $e) {
+            return false;
+        }
 
         $allowedTypes = [
             'image/jpeg',

--- a/Model/Export/ProductExportManager.php
+++ b/Model/Export/ProductExportManager.php
@@ -606,7 +606,7 @@ class ProductExportManager extends AbstractExportManager
      * @param string|null $url
      * @return bool
      */
-    private function isImageFormatAllowed(?string $url): bool
+    public function isImageFormatAllowed(?string $url): bool
     {
         $imageType = $this->fileinfoMimeTypeGuesser->guessMimeType($url);
 

--- a/Test/Integration/Export/CategoryExportDataTest.php
+++ b/Test/Integration/Export/CategoryExportDataTest.php
@@ -65,11 +65,6 @@ class CategoryExportDataTest extends AbstractTestCase
             'path://seo_title' => 'Category 1 Meta Title',
             'path://seo_keywords' => 'Category 1 Meta Keywords',
             'path://seo_description' => 'Category 1 Meta Description',
-            'path://image_url' =>
-                $this->store->getStore()->getBaseUrl(UrlInterface::URL_TYPE_MEDIA)
-                . ltrim(FileInfo::ENTITY_MEDIA_PATH, '/')
-                . '/'
-                . 'magento_small_image.jpg',
             'path://published' => 1,
             'path://order' => '1',
             'path://parent_slug' => null,

--- a/Test/Integration/Export/CategoryExportDataTest.php
+++ b/Test/Integration/Export/CategoryExportDataTest.php
@@ -65,6 +65,7 @@ class CategoryExportDataTest extends AbstractTestCase
             'path://seo_title' => 'Category 1 Meta Title',
             'path://seo_keywords' => 'Category 1 Meta Keywords',
             'path://seo_description' => 'Category 1 Meta Description',
+            'path://image_url' => NULL,
             'path://published' => 1,
             'path://order' => '1',
             'path://parent_slug' => null,

--- a/Test/Integration/_files/categories.php
+++ b/Test/Integration/_files/categories.php
@@ -74,7 +74,6 @@ $category->setId(3)
     ->setMetaTitle('Category 1 Meta Title')
     ->setMetaKeywords('Category 1 Meta Keywords')
     ->setMetaDescription('Category 1 Meta Description')
-    ->setImage('magento_small_image.jpg')
     ->save();
 
 $category = $categoryFactory->create();


### PR DESCRIPTION
 - Reused Product export's method isImageFormatAllowed() in order to validate category images during export;
 - Handled case when file does not exist or not readable