### PR TITLE
CU-8695d1mmp Product export: handle configurable products 'kind', related simple product and its type

### DIFF
--- a/Model/Export/BlueprintExportManager.php
+++ b/Model/Export/BlueprintExportManager.php
@@ -80,7 +80,7 @@ class BlueprintExportManager extends AbstractExportManager
      * @param array $configurableAttributes
      * @return array
      */
-    private function buildBlueprintData(array $configurableAttributes): array
+    public function buildBlueprintData(array $configurableAttributes): array
     {
         $attributeData = [];
         $skuPattern = "{{sku}}";


### PR DESCRIPTION
 - Implemented logic that populates 'path://product.configurable_product_kind.alias' and 'path://product.configurable_product.sku' fields during order export;
 - Handled type field for simple product assigned to config ones.