### PR TITLE
CU-8695eburm Blueprints Export: multi-word attribute mapped incorrectly

### DIFF
--- a/Model/Export/BlueprintExportManager.php
+++ b/Model/Export/BlueprintExportManager.php
@@ -57,7 +57,6 @@ class BlueprintExportManager extends AbstractExportManager
                     $attributeCode = $this->formatAlias($configurableAttribute['attribute_code']);
                     if (!isset($result[$attributeCode])) {
                         $result[self::ADD_HEADER_FLAG . $attributeCode] = $this->buildBlueprintData([$configurableAttribute]);
-                        $result[self::ADD_HEADER_FLAG . $attributeCode]['ignore_row'] = true;
                     }
                 }
                 $result[ $kind['path://alias']] = $kind;

--- a/Model/Export/BlueprintExportManager.php
+++ b/Model/Export/BlueprintExportManager.php
@@ -172,9 +172,8 @@ class BlueprintExportManager extends AbstractExportManager
                     }
                 }
             } else{
-                $dataRow[$key] = $this->isLabelItemMatchHeader($dataRow['path://name'], $value ) ? 'yes' : 'no';
+                $dataRow[$key] = $this->isLabelItemMatchHeader($dataRow['path://name'], $value) ? 'yes' : 'no';
             }
-
         }
 
         return $dataRow;
@@ -187,6 +186,15 @@ class BlueprintExportManager extends AbstractExportManager
      */
     private function isLabelItemMatchHeader(string $labelItem, string $headerLabel): bool
     {
-        return str_starts_with($headerLabel, $labelItem) && !str_contains($headerLabel, 'Synchronized');
+        $match = false;
+        if (str_contains($headerLabel, ' (Configurable)') && !str_contains($headerLabel, ' (Synchronized)')) {
+            $modifiedLabel = str_replace(' (Configurable)', '', $headerLabel);
+
+            if ($modifiedLabel === $labelItem) {
+                $match = true;
+            }
+        }
+
+        return $match;
     }
 }

--- a/Model/Export/BlueprintExportManager.php
+++ b/Model/Export/BlueprintExportManager.php
@@ -53,6 +53,13 @@ class BlueprintExportManager extends AbstractExportManager
             if (count($configurableAttributes) === 1) {
                 $result[self::ADD_HEADER_FLAG . $kind['path://alias']] = $kind;
             } else {
+                foreach ($configurableAttributes as $configurableAttribute) {
+                    $attributeCode = $this->formatAlias($configurableAttribute['attribute_code']);
+                    if (!isset($result[$attributeCode])) {
+                        $result[self::ADD_HEADER_FLAG . $attributeCode] = $this->buildBlueprintData([$configurableAttribute]);
+                        $result[self::ADD_HEADER_FLAG . $attributeCode]['ignore_row'] = true;
+                    }
+                }
                 $result[ $kind['path://alias']] = $kind;
             }
         }
@@ -158,24 +165,5 @@ class BlueprintExportManager extends AbstractExportManager
         }
 
         return $row;
-    }
-
-    /**
-     * @param string $labelItem
-     * @param string $headerLabel
-     * @return bool
-     */
-    private function isLabelItemMatchHeader(string $labelItem, string $headerLabel): bool
-    {
-        $match = false;
-        if (str_contains($headerLabel, ' (Configurable)') && !str_contains($headerLabel, ' (Synchronized)')) {
-            $modifiedLabel = str_replace(' (Configurable)', '', $headerLabel);
-
-            if ($modifiedLabel === $labelItem) {
-                $match = true;
-            }
-        }
-
-        return $match;
     }
 }

--- a/Model/Export/CsvFileContent.php
+++ b/Model/Export/CsvFileContent.php
@@ -137,9 +137,7 @@ class CsvFileContent
             }
             foreach ($exportData as $dataRow) {
                 if ($entityType == self::BLUEPRINT_ENTITY) {
-                    if (!array_key_exists('ignore_row', $dataRow)) {
-                        $dataRow = $this->blueprintExportManager->getBlueprintRow($headerColsData['cols'], $dataRow);
-                    }
+                    $dataRow = $this->blueprintExportManager->getBlueprintRow($headerColsData['cols'], $dataRow);
                 }
                 if ($entityType == self::ATTRIBUTE_ENTITY) {
                     $dataRow = $this->attributeExportManager->getAttributeRow($headerColsData['labels'], $dataRow);

--- a/Model/Export/CsvFileContent.php
+++ b/Model/Export/CsvFileContent.php
@@ -137,7 +137,9 @@ class CsvFileContent
             }
             foreach ($exportData as $dataRow) {
                 if ($entityType == self::BLUEPRINT_ENTITY) {
-                    $dataRow = $this->blueprintExportManager->getBlueprintRow($headerColsData['cols'], $dataRow);
+                    if (!array_key_exists('ignore_row', $dataRow)) {
+                        $dataRow = $this->blueprintExportManager->getBlueprintRow($headerColsData['cols'], $dataRow);
+                    }
                 }
                 if ($entityType == self::ATTRIBUTE_ENTITY) {
                     $dataRow = $this->attributeExportManager->getAttributeRow($headerColsData['labels'], $dataRow);

--- a/Model/Export/CsvFileContent.php
+++ b/Model/Export/CsvFileContent.php
@@ -137,10 +137,7 @@ class CsvFileContent
             }
             foreach ($exportData as $dataRow) {
                 if ($entityType == self::BLUEPRINT_ENTITY) {
-                    if (!array_key_exists('ignore_row', $dataRow)) {
-                        $dataRow = $this->blueprintExportManager->getBlueprintRow($headerColsData['labels'], $dataRow);
-                    }
-
+                    $dataRow = $this->blueprintExportManager->getBlueprintRow($headerColsData['cols'], $dataRow);
                 }
                 if ($entityType == self::ATTRIBUTE_ENTITY) {
                     $dataRow = $this->attributeExportManager->getAttributeRow($headerColsData['labels'], $dataRow);

--- a/Model/Export/ProductExportManager.php
+++ b/Model/Export/ProductExportManager.php
@@ -816,7 +816,7 @@ class ProductExportManager extends AbstractExportManager
         $configurableAttributes = $product->getTypeInstance()->getConfigurableAttributesAsArray($product);
         $blueprint = $this->blueprintExportManager->buildBlueprintData($configurableAttributes);
 
-        return  array_key_exists('alias', $blueprint) ? $blueprint['alias'] : null;
+        return  array_key_exists('path://alias', $blueprint) ? $blueprint['path://alias'] : null;
     }
 
     /**

--- a/Test/Integration/Export/BlueprintExportDataTest.php
+++ b/Test/Integration/Export/BlueprintExportDataTest.php
@@ -79,6 +79,30 @@ class BlueprintExportDataTest extends AbstractTestCase
                 'Storekeeper Shoe Size (Synchronized)'
             ],
             2 => [
+                'Storekeeper Color',
+                'sk_color',
+                "{{sku}}-{{content_vars['sk_color']['value']}}",
+                "{{title}}-{{content_vars['sk_color']['value_label']}}",
+                'yes',
+                'no',
+                'no',
+                'no',
+                'no',
+                'no'
+            ],
+            3 => [
+                'Storekeeper Size',
+                'sk_size',
+                "{{sku}}-{{content_vars['sk_size']['value']}}",
+                "{{title}}-{{content_vars['sk_size']['value_label']}}",
+                'no',
+                'no',
+                'yes',
+                'no',
+                'no',
+                'no'
+            ],
+            4 => [
                 'Storekeeper Color & Storekeeper Size',
                 'sk_color-sk_size',
                 "{{sku}}-{{content_vars['sk_color']['value']}}-{{content_vars['sk_size']['value']}}",
@@ -90,7 +114,7 @@ class BlueprintExportDataTest extends AbstractTestCase
                 'no',
                 'no'
             ],
-            3 => [
+            5 => [
                 'Storekeeper Shoe Size',
                 'sk_shoe_size',
                 "{{sku}}-{{content_vars['sk_shoe_size']['value']}}",


### PR DESCRIPTION
 - Corrected isLabelItemMatchHeader() in order to compare whole attribute label during blueprint export, instead of only first word.