### PR TITLE
CU-8695f68zt Product Export: image duplicates during save from SK

### DIFF
--- a/Helper/Api/Products.php
+++ b/Helper/Api/Products.php
@@ -1149,6 +1149,7 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
                     /**
                      * Load product item with latest id
                      * because framework does not allow to receive gallery item via addImageToMediaGallery() call
+                     * there is nothing to match against, the file path is changed when saving
                      */
                     $galleryImage = $target->getMediaGalleryImages()->getLastItem();
                     // Assign SK image id for newly created M2 gallery image

--- a/Helper/Api/Products.php
+++ b/Helper/Api/Products.php
@@ -1135,11 +1135,12 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
                     if (isset($flat_product['main_image']) && $flat_product['main_image']['id'] == $imageId) {
                         $mainImage = true;
                     }
-                    $shouldUpdate = $this->setGalleryImage($product_image['big_url'], $target, $mainImage);
+                    $shouldUpdate = $this->setGalleryImage($product_image['big_url'], $target, $mainImage)
+                        || $shouldUpdate;
                     if ($shouldUpdate) {
                         /**
                          * Save product via repository fo any given image
-                         * Otherwise new gallery item will not be available
+                         * Otherwise new gallery item will not be available, we only get the id after saving to storage
                          */
                         $this->productRepository->save($target);
                         $shouldUpdate = false;

--- a/Helper/Api/Products.php
+++ b/Helper/Api/Products.php
@@ -76,6 +76,7 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
     private OptionsFactory $optionsFactory;
     private ProductDescriptionHelper $productDescription;
     private ResourceConnection $resourceConnection;
+    private ProductExportManager $productExportManager;
     private array $_simpleProductIds = [];
 
     /**
@@ -142,7 +143,8 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
         Configurable $configurable,
         OptionsFactory $optionsFactory,
         ProductDescriptionHelper $productDescription,
-        ResourceConnection $resourceConnection
+        ResourceConnection $resourceConnection,
+        ProductExportManager $productExportManager
     ) {
         $this->authHelper = $authHelper;
         $this->productFactory = $productFactory;
@@ -173,6 +175,7 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
         $this->optionsFactory = $optionsFactory;
         $this->productDescription = $productDescription;
         $this->resourceConnection = $resourceConnection;
+        $this->productExportManager = $productExportManager;
     }
 
     /**
@@ -1107,7 +1110,10 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
                  * Look for storekeeper image id of current gallery image in array of images from SK backoffice
                  * if current product does not match id or id is missing - remove gallery image
                  */
-                if (!in_array($skImageId, $skImageIds)) {
+                if (
+                    !in_array($skImageId, $skImageIds)
+                    && $this->productExportManager->isImageFormatAllowed($mediaGalleryImage->getPath())
+                ) {
                     unset($galleryImages[$entryId]);
                     $target->setMediaGalleryEntries($galleryImages);
 

--- a/Helper/Api/Products.php
+++ b/Helper/Api/Products.php
@@ -1135,10 +1135,8 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
                     }
                     $target = $this->productRepository->get($target->getSku());
                     $galleryImage = $target->getMediaGalleryImages()->getLastItem();
-                    if ($galleryImage->getId()) {
-                        // Assign SK image id for newly created M2 gallery image
-                        $this->setStorekeeperImageId($galleryImage->getId(), $imageId);
-                    }
+                    // Assign SK image id for newly created M2 gallery image
+                    $this->setStorekeeperImageId($galleryImage->getId(), $imageId);
                 }
             }
         }

--- a/Plugin/Product/Gallery.php
+++ b/Plugin/Product/Gallery.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace StoreKeeper\StoreKeeper\Plugin\Product;
+
+class Gallery
+{
+    /**
+     * Add new columns to the regular media gallery select
+     *
+     * @param \Magento\Catalog\Model\ResourceModel\Product\Gallery $subject
+     * @param \Magento\Framework\DB\Select $select
+     * @return \Magento\Framework\DB\Select
+     */
+    public function afterCreateBatchBaseSelect(
+        \Magento\Catalog\Model\ResourceModel\Product\Gallery $subject,
+        \Magento\Framework\DB\Select $select
+    ) {
+        $select->columns(['storekeeper_image_id']);
+
+        return $select;
+    }
+}

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace StoreKeeper\StoreKeeper\Setup;
+
+use Magento\Catalog\Model\ResourceModel\Product\Gallery;
+use Magento\Framework\Setup\UpgradeSchemaInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+
+class UpgradeSchema implements UpgradeSchemaInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
+    {
+        $setup->startSetup();
+
+        $setup->getConnection()->addColumn(
+            $setup->getTable(Gallery::GALLERY_TABLE),
+            'storekeeper_image_id',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+                'unsigned' => true,
+                'nullable' => true,
+                'comment' => 'StoreKeeper Image Id'
+            ]
+        );
+
+        $setup->endSetup();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "suggest": {
     },
     "type": "magento2-module",
-    "version": "2.1.21",
+    "version": "2.1.22",
     "license": [
         "LGPL-3.0-only"
     ],

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -57,6 +57,9 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Catalog\Model\ResourceModel\Product\Gallery">
+        <plugin name="afterCreateBatchBaseSelect" type="StoreKeeper\StoreKeeper\Plugin\Product\Gallery" sortOrder="10" disabled="false"/>
+    </type>
 
     <virtualType name="StoreKeeper\StoreKeeper\Model\ResourceModel\EventLog\Grid\Collection" type="Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult">
         <arguments>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="StoreKeeper_StoreKeeper" setup_version="2.1.21">
+    <module name="StoreKeeper_StoreKeeper" setup_version="2.1.22">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
 - Reworked Products sync processImages() in a way of validating new/existing product images by 'storekeeper_image_id' stored in 'catalog_product_entity_media_gallery' db table;
 - Create gallery plugin which adds 'storekeeper_image_id' field to media gallery collection result;
 - Raised module version in order to trigger db schema update.