### PR TITLE
CU-8695jrbb6 Product Stock Management: handle M2 stock reservations

### DIFF
--- a/Helper/Api/Auth.php
+++ b/Helper/Api/Auth.php
@@ -201,6 +201,18 @@ class Auth extends \Magento\Framework\App\Helper\AbstractHelper
         return $this->storeManager->getStore()->getBaseUrl();
     }
 
+
+    /**
+     * Get Store Id
+     *
+     * @return string
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getStoreId(): string
+    {
+        return $this->storeManager->getStore()->getId();
+    }
+
     /**
      * Get ShopName config value
      *

--- a/Plugin/Magento/InventorySalesApi/Api/DisableStockReservations.php
+++ b/Plugin/Magento/InventorySalesApi/Api/DisableStockReservations.php
@@ -1,0 +1,46 @@
+<?php
+namespace StoreKeeper\StoreKeeper\Plugin\Magento\InventorySalesApi\Api;
+
+use Magento\InventorySalesApi\Api\PlaceReservationsForSalesEventInterface;
+use Magento\InventorySalesApi\Api\Data\ReservationInterface;
+use StoreKeeper\StoreKeeper\Helper\Api\Auth;
+use StoreKeeper\StoreKeeper\Helper\Config;
+
+class DisableStockReservations
+{
+    /**
+     * Constructor
+     *
+     * @param Auth $authHelper
+     * @param Config $configHelper
+     */
+    public function __construct (
+        Auth $authHelper,
+        Config $configHelper
+    ) {
+        $this->authHelper = $authHelper;
+        $this->configHelper = $configHelper;
+    }
+
+    /**
+     * Disable reservations for sales events
+     *
+     * @param PlaceReservationsForSalesEventInterface $subject
+     * @param callable $proceed
+     * @param ReservationInterface[] $reservations
+     * @return void
+     */
+    public function aroundExecute(
+        PlaceReservationsForSalesEventInterface $subject,
+        callable $proceed,
+        array $reservations
+    ) {
+        $storeId = $this->authHelper->getStoreId();
+        if (
+            $this->authHelper->isConnected($storeId)
+            && $this->configHelper->hasMode($storeId, Config::SYNC_PRODUCTS | Config::SYNC_ALL)
+        ) {
+            return;
+        }
+    }
+}

--- a/Plugin/Magento/InventorySalesApi/Api/DisableStockReservations.php
+++ b/Plugin/Magento/InventorySalesApi/Api/DisableStockReservations.php
@@ -41,6 +41,8 @@ class DisableStockReservations
             && $this->configHelper->hasMode($storeId, Config::SYNC_PRODUCTS | Config::SYNC_ALL)
         ) {
             return;
+        } else {
+            return $proceed($reservations);
         }
     }
 }

--- a/Plugin/Magento/InventorySalesApi/Api/DisableStockReservations.php
+++ b/Plugin/Magento/InventorySalesApi/Api/DisableStockReservations.php
@@ -3,6 +3,8 @@ namespace StoreKeeper\StoreKeeper\Plugin\Magento\InventorySalesApi\Api;
 
 use Magento\InventorySalesApi\Api\PlaceReservationsForSalesEventInterface;
 use Magento\InventorySalesApi\Api\Data\ReservationInterface;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+use Magento\InventorySalesApi\Api\Data\SalesEventInterface;
 use StoreKeeper\StoreKeeper\Helper\Api\Auth;
 use StoreKeeper\StoreKeeper\Helper\Config;
 
@@ -34,8 +36,8 @@ class DisableStockReservations
         PlaceReservationsForSalesEventInterface $subject,
         callable $proceed,
         array $items,
-        \Magento\InventorySalesApi\Api\Data\SalesChannelInterface $salesChannel,
-        \Magento\InventorySalesApi\Api\Data\SalesEventInterface $salesEvent
+        SalesChannelInterface $salesChannel,
+        SalesEventInterface $salesEvent
     ) {
         $storeId = $this->authHelper->getStoreId();
         if (

--- a/Plugin/Magento/InventorySalesApi/Api/DisableStockReservations.php
+++ b/Plugin/Magento/InventorySalesApi/Api/DisableStockReservations.php
@@ -33,7 +33,9 @@ class DisableStockReservations
     public function aroundExecute(
         PlaceReservationsForSalesEventInterface $subject,
         callable $proceed,
-        array $reservations
+        array $items,
+        \Magento\InventorySalesApi\Api\Data\SalesChannelInterface $salesChannel,
+        \Magento\InventorySalesApi\Api\Data\SalesEventInterface $salesEvent
     ) {
         $storeId = $this->authHelper->getStoreId();
         if (
@@ -42,7 +44,7 @@ class DisableStockReservations
         ) {
             return;
         } else {
-            return $proceed($reservations);
+            return $proceed($items, $salesChannel, $salesEvent);
         }
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -60,6 +60,9 @@
     <type name="Magento\Catalog\Model\ResourceModel\Product\Gallery">
         <plugin name="afterCreateBatchBaseSelect" type="StoreKeeper\StoreKeeper\Plugin\Product\Gallery" sortOrder="10" disabled="false"/>
     </type>
+    <type name="Magento\InventorySalesApi\Api\PlaceReservationsForSalesEventInterface">
+        <plugin name="storekeeperm2plugin_disable_stock_reservations_plugin" type="StoreKeeper\StoreKeeper\Plugin\Magento\InventorySalesApi\Api\DisableStockReservations" />
+    </type>
 
     <virtualType name="StoreKeeper\StoreKeeper\Model\ResourceModel\EventLog\Grid\Collection" type="Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult">
         <arguments>


### PR DESCRIPTION
 - Added DisableStockReservations plugin which ignores Magento's attempt to decrease "orderable stock" when SK sync mode set to 'Products' or 'All'. In this case SK backoffice will handle stock on itself and we do not need to lower Magento's orderable stock on the fly.