### PR TITLE
Cu 869625p3u Order Sync: extend Mass action logic

### DIFF
--- a/Api/ApiClient.php
+++ b/Api/ApiClient.php
@@ -8,12 +8,14 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use StoreKeeper\ApiWrapper\ModuleApiWrapperInterface;
 use StoreKeeper\ApiWrapper\Auth;
 use StoreKeeper\StoreKeeper\Logger\Logger;
+use StoreKeeper\StoreKeeper\Helper\Api\Auth as AuthHelper;
 
 class ApiClient
 {
     protected ScopeConfigInterface $scopeConfig;
     protected Logger $logger;
     protected ?Auth $auth = null;
+    protected AuthHelper $authHelper;
 
     /**
      * ApiClient constructor.
@@ -22,10 +24,12 @@ class ApiClient
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
-        Logger $logger
+        Logger $logger,
+        AuthHelper $authHelper
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->logger = $logger;
+        $this->authHelper = $authHelper;
     }
 
     /**
@@ -58,6 +62,7 @@ class ApiClient
      */
     protected function getModule(string $module, string $storeId): ModuleApiWrapperInterface
     {
+        $storeId = $this->authHelper->getStoreId($storeId);
         $api = new ApiWrapper($this->getAdapter($storeId), $this->getAuthWrapper($storeId));
         return $api->getModule($module);
     }

--- a/Api/AttributeApiClient.php
+++ b/Api/AttributeApiClient.php
@@ -7,7 +7,7 @@ namespace StoreKeeper\StoreKeeper\Api;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use StoreKeeper\ApiWrapper\ModuleApiWrapperInterface;
 use StoreKeeper\StoreKeeper\Logger\Logger;
-
+use StoreKeeper\StoreKeeper\Helper\Api\Auth as AuthHelper;
 /**
  * ApiWrapper for SK ShopModule which will provide access to attribute type and options in future
  */
@@ -20,12 +20,14 @@ class AttributeApiClient extends ApiClient
      *
      * @param ScopeConfigInterface $scopeConfig
      * @param Logger $logger
+     * @param AuthHelper $authHelper
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
-        Logger $logger
+        Logger $logger,
+        AuthHelper $authHelper
     ) {
-        parent::__construct($scopeConfig, $logger);
+        parent::__construct($scopeConfig, $logger, $authHelper);
     }
 
     /**

--- a/Api/PaymentApiClient.php
+++ b/Api/PaymentApiClient.php
@@ -10,11 +10,11 @@ use StoreKeeper\StoreKeeper\Api\OrderApiClient;
 use StoreKeeper\ApiWrapper\ModuleApiWrapperInterface;
 use StoreKeeper\ApiWrapper\Exception\GeneralException;
 use StoreKeeper\StoreKeeper\Logger\Logger;
+use StoreKeeper\StoreKeeper\Helper\Api\Auth as AuthHelper;
 
 class PaymentApiClient extends ApiClient
 {
     private const STOREKEEPER_PAYMENT_MODULE_NAME = 'PaymentModule';
-
     private OrderApiClient $orderApiClient;
 
     /**
@@ -24,9 +24,10 @@ class PaymentApiClient extends ApiClient
     public function __construct(
         ScopeConfigInterface $scopeConfig,
         Logger $logger,
-        OrderApiClient $orderApiClient
+        OrderApiClient $orderApiClient,
+        AuthHelper $authHelper
     ) {
-        parent::__construct($scopeConfig, $logger);
+        parent::__construct($scopeConfig, $logger, $authHelper);
         $this->orderApiClient = $orderApiClient;
     }
 

--- a/Api/ProductApiClient.php
+++ b/Api/ProductApiClient.php
@@ -25,7 +25,7 @@ class ProductApiClient extends ApiClient
     private ProductUrl $productUrl;
     private BackendUrl $backendUrl;
     private DateTime $dateTime;
-    private AuthHelper $authHelper;
+    protected AuthHelper $authHelper;
 
     public function __construct(
         ScopeConfigInterface $scopeConfig,

--- a/Api/ProductApiClient.php
+++ b/Api/ProductApiClient.php
@@ -27,6 +27,17 @@ class ProductApiClient extends ApiClient
     private DateTime $dateTime;
     protected AuthHelper $authHelper;
 
+    /**
+     * Constructor
+     *
+     * @param ScopeConfigInterface $scopeConfig
+     * @param \StoreKeeper\StoreKeeper\Api\OrderApiClient $orderApiClient
+     * @param ProductUrl $productUrl
+     * @param BackendUrl $backendUrl
+     * @param DateTime $dateTime
+     * @param AuthHelper $authHelper
+     * @param Logger $logger
+     */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
         OrderApiClient $orderApiClient,
@@ -36,7 +47,7 @@ class ProductApiClient extends ApiClient
         AuthHelper $authHelper,
         Logger $logger
     ) {
-        parent::__construct($scopeConfig, $logger);
+        parent::__construct($scopeConfig, $logger, $authHelper);
         $this->orderApiClient = $orderApiClient;
         $this->productUrl = $productUrl;
         $this->backendUrl = $backendUrl;

--- a/Api/Webhook/Webhook.php
+++ b/Api/Webhook/Webhook.php
@@ -92,10 +92,12 @@ class Webhook
             return $this->response($response->getContent(), $response->getStatusCode());
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage(), $this->logger->buildReportData($e));
-            return $this->response([
+            $response = $this->jsonResponse->setData([
                 'success' => false,
                 'message' => "An error occurred: {$e->getMessage()}"
             ]);
+
+            return $this->response($response->getContent(), $response->getStatusCode());
         }
     }
 

--- a/Helper/Api/Auth.php
+++ b/Helper/Api/Auth.php
@@ -9,7 +9,6 @@ use Magento\Framework\Math\Random;
 use Magento\Framework\Module\ModuleList;
 use Magento\Store\Model\StoreManagerInterface;
 use Ramsey\Uuid\Generator\PeclUuidRandomGenerator;
-use StoreKeeper\StoreKeeper\Api\OrderApiClient;
 use StoreKeeper\StoreKeeper\Helper\Config;
 
 class Auth extends \Magento\Framework\App\Helper\AbstractHelper
@@ -29,7 +28,6 @@ class Auth extends \Magento\Framework\App\Helper\AbstractHelper
     private PeclUuidRandomGenerator $uuidRandomGenerator;
     private ProductMetadataInterface $productMetadata;
     private ModuleList $moduleList;
-    private OrderApiClient $orderApiClient;
     private Config $configHelper;
 
     /**
@@ -43,7 +41,6 @@ class Auth extends \Magento\Framework\App\Helper\AbstractHelper
      * @param PeclUuidRandomGenerator $uuidRandomGenerator
      * @param ProductMetadataInterface $productMetadata
      * @param ModuleList $moduleList
-     * @param OrderApiClient $orderApiClient
      * @param Config $configHelper
      */
     public function __construct(
@@ -55,7 +52,6 @@ class Auth extends \Magento\Framework\App\Helper\AbstractHelper
         PeclUuidRandomGenerator $uuidRandomGenerator,
         ProductMetadataInterface $productMetadata,
         ModuleList $moduleList,
-        OrderApiClient $orderApiClient,
         Config $configHelper
     ) {
         $this->scopeConfig = $scopeConfig;
@@ -66,7 +62,6 @@ class Auth extends \Magento\Framework\App\Helper\AbstractHelper
         $this->uuidRandomGenerator = $uuidRandomGenerator;
         $this->productMetadata = $productMetadata;
         $this->moduleList = $moduleList;
-        $this->orderApiClient = $orderApiClient;
         $this->configHelper = $configHelper;
     }
 

--- a/Helper/Info.php
+++ b/Helper/Info.php
@@ -198,9 +198,13 @@ class Info
             ->addAttributeToSort('created_at', 'desc')
             ->setPageSize(1)
             ->setCurPage(1);
-        $lastOrder = $orderCollection->getFirstItem();
-        $lastOrderDateTime = $this->timezone->date(strtotime($lastOrder->getCreatedAt()))
-            ->format(\StoreKeeper\StoreKeeper\Api\Webhook\Webhook::DATE_TIME_FORMAT);
+        if ($orderCollection->count() > 0) {
+            $lastOrder = $orderCollection->getFirstItem();
+            $lastOrderDateTime = $this->timezone->date(strtotime($lastOrder->getCreatedAt()))
+                ->format(\StoreKeeper\StoreKeeper\Api\Webhook\Webhook::DATE_TIME_FORMAT);
+        } else {
+            $lastOrderDateTime = '';
+        }
 
         return $lastOrderDateTime;
     }

--- a/Helper/Info.php
+++ b/Helper/Info.php
@@ -230,9 +230,13 @@ class Info
         $failedOrders = $this->storeKeeperFailedSyncOrderCollectionFactory->create()
             ->addFieldToFilter('is_failed', 1)
             ->addOrder('updated_at');
-        $lastFailedOrder = $failedOrders->getFirstItem();
-        $lastFailedOrderDateTime = $this->timezone->date(strtotime($lastFailedOrder->getData('updated_at')))
-            ->format(\StoreKeeper\StoreKeeper\Api\Webhook\Webhook::DATE_TIME_FORMAT);
+        if ($failedOrders->count() > 0) {
+            $lastFailedOrder = $failedOrders->getFirstItem();
+            $lastFailedOrderDateTime = $this->timezone->date(strtotime($lastFailedOrder->getData('updated_at')))
+                ->format(\StoreKeeper\StoreKeeper\Api\Webhook\Webhook::DATE_TIME_FORMAT);
+        } else {
+            $lastFailedOrderDateTime = '';
+        }
 
         return $lastFailedOrderDateTime;
     }

--- a/Model/OrderSync/Shipment.php
+++ b/Model/OrderSync/Shipment.php
@@ -4,26 +4,48 @@ declare(strict_types=1);
 
 namespace StoreKeeper\StoreKeeper\Model\OrderSync;
 
+use Magento\Framework\Message\ManagerInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Model\OrderRepository;
 use StoreKeeper\StoreKeeper\Api\OrderApiClient;
+use StoreKeeper\StoreKeeper\Helper\Api\Orders as ApiOrders;
+use StoreKeeper\StoreKeeper\Logger\Logger;
 
 class Shipment
 {
     private OrderApiClient $orderApiClient;
     private OrderRepository $orderRepository;
+    private ApiOrders $apiOrders;
+    private Json $json;
+    private Logger $logger;
+    private ManagerInterface $messageManager;
 
     /**
      * Constructor
      *
      * @param OrderApiClient $orderApiClient
      * @param OrderRepository $orderRepository
+     * @param ApiOrders $apiOrders
+     * @param Json $json
+     * @param Logger $logger
+     * @param ManagerInterface $messageManager
      */
     public function __construct(
         OrderApiClient $orderApiClient,
-        OrderRepository $orderRepository
+        OrderRepository $orderRepository,
+        ApiOrders $apiOrders,
+        Json $json,
+        Logger $logger,
+        ManagerInterface $messageManager
     ) {
         $this->orderApiClient = $orderApiClient;
         $this->orderRepository = $orderRepository;
+        $this->apiOrders = $apiOrders;
+        $this->json = $json;
+        $this->logger = $logger;
+        $this->messageManager = $messageManager;
+
     }
 
     /**
@@ -44,5 +66,66 @@ class Shipment
         );
 
         $this->orderApiClient->markOrderShipmentDelivered($data['store_id'], $shipmentId);
+    }
+
+    /**
+     * @param OrderInterface $order
+     * @param $storeId
+     * @return void
+     */
+    public function createShipment(OrderInterface $order, $storeId): void
+    {
+        $storekeeperId = $order->getStorekeeperId();
+
+        if ($this->apiOrders->allowShipmentCreation($order)) {
+            $shipmentData = [
+                'order_id' => $order->getId(),
+                'storekeeper_id' => $storekeeperId,
+                'store_id' => $storeId,
+                'items' => $this->getShipmentsItems($storeId, $storekeeperId)
+            ];
+
+            try {
+                $serializedData = $this->json->serialize($shipmentData);
+                $this->process($serializedData);
+                $order->setStorekeeperShipmentId($storekeeperId);
+            } catch (\Exception $e) {
+                $message = 'Error synchronizing shipment to StoreKeeper! Storekeeper order number: ' . $storekeeperId;
+                $this->logger->error(
+                    $message,
+                    [
+                        'error' =>  $this->logger->buildReportData($e),
+                        'request' =>  $serializedData
+                    ]
+                );
+
+                $this->messageManager->addNoticeMessage(__($message));
+            }
+        }
+    }
+    /**
+     * @param string $storeId
+     * @param string $storekeeperId
+     * @return array
+     */
+    private function getShipmentsItems(string $storeId, string $storekeeperId): array
+    {
+        $storeKeeperOrder = $this->apiOrders->getStoreKeeperOrder($storeId, $storekeeperId);
+        $shipmentItems = [];
+
+        if ($storeKeeperOrder) {
+            if (array_key_exists('order_items', $storeKeeperOrder)) {
+                foreach ($storeKeeperOrder['order_items'] as $orderItem) {
+                    if ($orderItem['is_shipping'] === false) {
+                        $shipmentItems[] = [
+                            'id' => $orderItem['id'],
+                            'quantity' => $orderItem['quantity']
+                        ];
+                    }
+                }
+            }
+        }
+
+        return $shipmentItems;
     }
 }

--- a/Observers/SalesOrderSaveBeforeObserver.php
+++ b/Observers/SalesOrderSaveBeforeObserver.php
@@ -5,13 +5,11 @@ use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
-use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\MessageQueue\PublisherInterface;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Sales\Model\Order;
 use StoreKeeper\StoreKeeper\Helper\Api\Auth;
 use StoreKeeper\StoreKeeper\Helper\Api\Orders as ApiOrders;
-use StoreKeeper\StoreKeeper\Logger\Logger;
 use StoreKeeper\StoreKeeper\Model\OrderSync\Shipment;
 
 class SalesOrderSaveBeforeObserver implements ObserverInterface
@@ -20,10 +18,7 @@ class SalesOrderSaveBeforeObserver implements ObserverInterface
     private Json $json;
     private PublisherInterface $publisher;
     private OrderRepositoryInterface $orderRepository;
-    private ApiOrders $apiOrders;
     private Shipment $shipment;
-    private Logger $logger;
-    private ManagerInterface $messageManager;
 
     /**
      * Constructor
@@ -32,29 +27,20 @@ class SalesOrderSaveBeforeObserver implements ObserverInterface
      * @param Json $json
      * @param PublisherInterface $publisher
      * @param OrderRepositoryInterface $orderRepository
-     * @param ApiOrders $apiOrders
      * @param Shipment $shipment
-     * @param Logger $logger
-     * @param ManagerInterface $messageManager
      */
     public function __construct(
         Auth $authHelper,
         Json $json,
         PublisherInterface $publisher,
         OrderRepositoryInterface $orderRepository,
-        ApiOrders $apiOrders,
-        Shipment $shipment,
-        Logger $logger,
-        ManagerInterface $messageManager
+        Shipment $shipment
     ) {
         $this->authHelper = $authHelper;
         $this->json = $json;
         $this->publisher = $publisher;
         $this->orderRepository = $orderRepository;
-        $this->apiOrders = $apiOrders;
         $this->shipment = $shipment;
-        $this->logger = $logger;
-        $this->messageManager = $messageManager;
     }
 
     /**
@@ -86,71 +72,10 @@ class SalesOrderSaveBeforeObserver implements ObserverInterface
                     );
 
                     if ($order->getStatus() == Order::STATE_COMPLETE) {
-                        $this->createShipment($order, $storeId);
+                        $this->shipment->createShipment($order, $storeId);
                     }
                 }
             }
         }
-    }
-
-    /**
-     * @param OrderInterface $order
-     * @param $storeId
-     * @return void
-     */
-    private function createShipment(OrderInterface $order, $storeId): void
-    {
-        $storekeeperId = $order->getStorekeeperId();
-
-        if ($this->apiOrders->allowShipmentCreation($order)) {
-            $shipmentData = [
-                'order_id' => $order->getId(),
-                'storekeeper_id' => $storekeeperId,
-                'store_id' => $storeId,
-                'items' => $this->getShipmentsItems($storeId, $storekeeperId)
-            ];
-
-            try {
-                $serializedData = $this->json->serialize($shipmentData);
-                $this->shipment->process($serializedData);
-                $order->setStorekeeperShipmentId($storekeeperId);
-            } catch (\Exception $e) {
-                $message = 'Error synchronizing shipment to StoreKeeper! Storekeeper order number: ' . $storekeeperId;
-                $this->logger->error(
-                    $message,
-                    [
-                        'error' =>  $this->logger->buildReportData($e),
-                        'request' =>  $serializedData
-                    ]
-                );
-
-                $this->messageManager->addNoticeMessage(__($message));
-            }
-        }
-    }
-    /**
-     * @param string $storeId
-     * @param string $storekeeperId
-     * @return array
-     */
-    private function getShipmentsItems(string $storeId, string $storekeeperId): array
-    {
-        $storeKeeperOrder = $this->apiOrders->getStoreKeeperOrder($storeId, $storekeeperId);
-        $shipmentItems = [];
-
-        if ($storeKeeperOrder) {
-            if (array_key_exists('order_items', $storeKeeperOrder)) {
-                foreach ($storeKeeperOrder['order_items'] as $orderItem) {
-                    if ($orderItem['is_shipping'] === false) {
-                        $shipmentItems[] = [
-                            'id' => $orderItem['id'],
-                            'quantity' => $orderItem['quantity']
-                        ];
-                    }
-                }
-            }
-        }
-
-        return $shipmentItems;
     }
 }

--- a/Test/Integration/ShipmentCreationTest.php
+++ b/Test/Integration/ShipmentCreationTest.php
@@ -50,7 +50,9 @@ class ShipmentCreationTest extends AbstractTestCase
             [
                 'orderApiClient' => $this->orderApiClientMock,
                 'orderRepository' => $this->orderRepository,
-                'orderResource' => $this->orderResource
+                'orderResource' => $this->orderResource,
+                'apiOrders' => $this->apiOrdersMock,
+                'json' => $this->json
             ]
         );
 
@@ -58,7 +60,6 @@ class ShipmentCreationTest extends AbstractTestCase
             \StoreKeeper\StoreKeeper\Observers\SalesOrderSaveBeforeObserver::class,
             [
                 'json' => $this->json,
-                'apiOrders' => $this->apiOrdersMock,
                 'shipment' => $this->shipment,
                 'authHelper' => $this->authHelper,
                 'orderRepository' => $this->orderRepository


### PR DESCRIPTION
 - Moved createShipment() method from Observer class to separate Shipment model in order to be able to reuse it;
 - Modified SetUp section for ShipmentCreationTest according to changes in observer event and Shipment model classes;
 - Added call of shipment creation during order sync mass action;
 - Updated constructors for classes that extends ApiClient;
 - Updated error response for webhook class. Handled empty response for failed tasks in Info class;
 - Updated getLastOrderDateTime() handling of 0 orders.