### PR TITLE
CU-869634tk2 Stock update: send saleable stock instead of real stock

### DIFF
--- a/Helper/Api/Products.php
+++ b/Helper/Api/Products.php
@@ -250,7 +250,7 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
 
             try {
                 if ($product = $this->exists($storeId, $result)) {
-                    $this->processStock($result, $result['flat_product'], $product->getSku());
+                    $this->processStock($result, $result['flat_product']['product'], $product->getSku());
                     $status = ProductApiClient::PRODUCT_UPDATE_STATUS_SUCCESS;
                 } else {
                     throw new \Exception("Product with StoreKeerep ID: {$storeKeeperId} does not exist in Magento");

--- a/Test/Integration/AbstractTestCase.php
+++ b/Test/Integration/AbstractTestCase.php
@@ -147,7 +147,8 @@ abstract class AbstractTestCase extends TestCase
                             'flat_product' => [
                                 'product' => [
                                     'product_stock' => [
-                                        'value' => self::UPDATED_STOCK_ITEM_VALUE
+                                        'value' => self::UPDATED_STOCK_ITEM_VALUE,
+                                        'unlimited' => false
                                     ],
                                     'sku' => 'simple-2'
                                 ]


### PR DESCRIPTION
 - Changed stock value received from sk during 'stock_updated' event from real stock to orderable stock;
 - Updated mock response for getNaturalSearchShopFlatProductForHooks() api method according to changes in stock processing.
 