### PR TITLE
Cu 86963x6ak Correct handling of 'Storekeeper Product Id' value

### DIFF
--- a/Api/OrderApiClient.php
+++ b/Api/OrderApiClient.php
@@ -128,6 +128,23 @@ class OrderApiClient extends ApiClient
         );
     }
 
+    public function getNaturalSearchShopFlatProductForHooksByProductId(string $language, string $storeId, string $storeKeeperId): array
+    {
+        return $this->getShopModule($storeId)->naturalSearchShopFlatProductForHooks(
+            ' ',
+            $language,
+            0,
+            1,
+            [],
+            [
+                [
+                    'name' => 'flat_product/product_id__=',
+                    'val' => $storeKeeperId
+                ]
+            ]
+        );
+    }
+
     /**
      * @param $storeId
      * @param $storekeeperProductId

--- a/Helper/Api/Attributes.php
+++ b/Helper/Api/Attributes.php
@@ -294,7 +294,7 @@ class Attributes extends AbstractHelper
                 ];
                 $this->productApiClient->setShopProductObjectSyncStatusForHook(
                     $storeId,
-                    (string)$flat_product['product_id'],
+                    (string)$flat_product['id'],
                     $target,
                     ProductApiClient::PRODUCT_UPDATE_STATUS_ERROR,
                     $exceptionData

--- a/Helper/Api/Products.php
+++ b/Helper/Api/Products.php
@@ -326,7 +326,7 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
         $storekeeperLinkSkus = [];
 
         foreach ($storekeeperLinkIds as $storekeeperLinkId) {
-            if ($linkedProduct = $this->exists($storeId, ['product_id' => $storekeeperLinkId])) {
+            if ($linkedProduct = $this->exists($storeId, ['id' => $storekeeperLinkId])) {
                 $storekeeperLinkSkus[] = $linkedProduct->getSku();
             }
         }
@@ -473,7 +473,7 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
         $websiteId = $this->getStoreWebsiteId($storeId);
 
         if ($target = $this->exists($storeId, [
-            'product_id' => $targetId
+            'id' => $targetId
         ])) {
             if (in_array($websiteId, $target->getWebsiteIds())) {
                 $target->setWebsiteIds(array_diff($target->getWebsiteIds(), [$websiteId]));
@@ -499,7 +499,7 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
     {
         $websiteId = $this->getStoreWebsiteId($storeId);
         if ($target = $this->exists($storeId, [
-            'product_id' => $targetId
+            'id' => $targetId
         ])) {
             $websiteIds = $target->getWebsiteIds();
             if (!in_array($websiteId, $websiteIds)) {
@@ -700,7 +700,7 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
      */
     private function getResultStoreKeeperId($result)
     {
-        return $result['product_id'];
+        return $result['id'];
     }
 
     /**

--- a/Test/Integration/AbstractTestCase.php
+++ b/Test/Integration/AbstractTestCase.php
@@ -154,6 +154,7 @@ abstract class AbstractTestCase extends TestCase
                                 ]
                             ],
                             'product_id' => 7,
+                            'id' => 7,
                             'orderable_stock_value' => self::UPDATED_STOCK_ITEM_VALUE
                         ]
                     ]

--- a/Test/Integration/ImportNewConfigurableProduct.php
+++ b/Test/Integration/ImportNewConfigurableProduct.php
@@ -71,7 +71,7 @@ class ImportNewConfigurableProduct extends AbstractTestCase
                     ],
                     'content_vars' => self::CONTENT_VARS
                 ],
-                'product_id' => 7,
+                'id' => 7,
                 'orderable_stock_value' => self::UPDATED_STOCK_ITEM_VALUE
             ]
         ]
@@ -103,7 +103,6 @@ class ImportNewConfigurableProduct extends AbstractTestCase
                     ],
                     'content_vars' => self::CONTENT_VARS
                 ],
-                'product_id' => 113,
                 'id' => 213,
                 'orderable_stock_value' => self::UPDATED_STOCK_ITEM_VALUE
 


### PR DESCRIPTION
 - Changed body of getResultStoreKeeperId() in order to get  'id' instead of 'product_id' from sk api product data response;
 - Changed all places in code to send 'id' param where getResultStoreKeeperId() reused;
 - Added method getNaturalSearchShopFlatProductForHooksByProductId() which allow to load products by 'product_id' in order to load current products with incorrect value and change it in custom script;
 - Updated integration test accordingly.