### PR TITLE
CU-869635vzp Product activated/deactivated event: enabling/disabling of product not working properly

### DIFF
--- a/Helper/Api/Auth.php
+++ b/Helper/Api/Auth.php
@@ -599,10 +599,18 @@ class Auth extends \Magento\Framework\App\Helper\AbstractHelper
          * Return admin store scope if store is in single-store mode or have only 1 storeview
          * Mitigates issues with configs and attributes scope
          */
-        if ($this->storeManager->isSingleStoreMode() || count($this->storeManager->getStores()) == 1) {
+        if ($this->isSingleStore()) {
             $storeId = \Magento\Store\Model\Store::DEFAULT_STORE_ID;
         }
 
         return $storeId;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSingleStore(): bool
+    {
+        return ($this->storeManager->isSingleStoreMode() || count($this->storeManager->getStores()) == 1) ?? false;
     }
 }

--- a/Helper/Api/Products.php
+++ b/Helper/Api/Products.php
@@ -475,9 +475,21 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
         if ($target = $this->exists($storeId, [
             'id' => $targetId
         ])) {
-            if (in_array($websiteId, $target->getWebsiteIds())) {
-                $target->setWebsiteIds(array_diff($target->getWebsiteIds(), [$websiteId]));
-                $this->productRepository->save($target);
+            if (!$this->authHelper->isSingleStore()) {
+                if (in_array($websiteId, $target->getWebsiteIds())) {
+                    $target->setWebsiteIds(array_diff($target->getWebsiteIds(), [$websiteId]));
+                    $this->productRepository->save($target);
+                }
+            } else {
+                /**
+                 * Use product status enable/disable to sctivate/deactivate product
+                 * Because 'Product in Websites' tab not available on admin panel for Single store shops
+                 */
+                $this->productAction->updateAttributes(
+                    [$target->getId()],
+                    ['status' => Status::STATUS_DISABLED],
+                    \Magento\Store\Model\Store::DEFAULT_STORE_ID
+                );
             }
         } else {
             $this->updateById($storeId, $targetId);
@@ -501,11 +513,23 @@ class Products extends \Magento\Framework\App\Helper\AbstractHelper
         if ($target = $this->exists($storeId, [
             'id' => $targetId
         ])) {
-            $websiteIds = $target->getWebsiteIds();
-            if (!in_array($websiteId, $websiteIds)) {
-                $websiteIds[] = $websiteId;
-                $target->setWebsiteIds($websiteIds);
-                $target = $this->productRepository->save($target);
+            if (!$this->authHelper->isSingleStore()) {
+                $websiteIds = $target->getWebsiteIds();
+                if (!in_array($websiteId, $websiteIds)) {
+                    $websiteIds[] = $websiteId;
+                    $target->setWebsiteIds($websiteIds);
+                    $target = $this->productRepository->save($target);
+                }
+            } else {
+                /**
+                 * Use product status enable/disable to sctivate/deactivate product
+                 * Because 'Product in Websites' tab not available on admin panel for Single store shops
+                 */
+                $this->productAction->updateAttributes(
+                    [$target->getId()],
+                    ['status' => Status::STATUS_ENABLED],
+                    \Magento\Store\Model\Store::DEFAULT_STORE_ID
+                );
             }
         } else {
             $this->updateById($websiteId, $targetId);


### PR DESCRIPTION
 - Changed processing of activated/deactivated webhook event for single-store shops: they did not have tab 'Product in Websites' which controlled by setWebsiteIds() setter in code, so Magento's response to activation/deactivation webhook event was changed to setting product status in enabled/disabled state accordingly.