### PR TITLE
CU-8696tvx9v (FT Products) Pick up order from Magento not in StoreKeeper

### DIFF
--- a/Helper/Api/Orders.php
+++ b/Helper/Api/Orders.php
@@ -695,6 +695,7 @@ class Orders extends AbstractHelper
      */
     public function onCreate(Order $order): void
     {
+        $payload = [];
         try {
             $storeId = $order->getStoreid();
             $payload = $this->prepareOrder($order, false);

--- a/Model/OrderSync/Consumer.php
+++ b/Model/OrderSync/Consumer.php
@@ -100,7 +100,7 @@ class Consumer
             } catch(\Exception $e) {
                 $this->logger->error($e->getMessage(), $this->logger->buildReportData($e));
                 if (!$storeKeeperFailedSyncOrder->hasData('order_id')) {
-                    $storeKeeperFailedSyncOrder->setOrderId((int)$orderId);
+                    $storeKeeperFailedSyncOrder->setOrderId($order->getId());
                     $storeKeeperFailedSyncOrder->setIsFailed(1);
                     $storeKeeperFailedSyncOrder->setExceptionMessage($e->getMessage());
                     $order->setStorekeeperOrderLastSync(time());


### PR DESCRIPTION
 - Mitigated case when SK order sync exception being thrown with missing payload variable;
 - Corrected order_id assignment during failed order sync record (previously it recorded increment id hinted to int, which resulted in incorrect results for "Storekeeper Failed Sync Order" column results.