### PR TITLE
CU-8697y4nn9 Magento: process stock update during product 'updated' event

### DIFF
--- a/Api/Webhook/Webhook.php
+++ b/Api/Webhook/Webhook.php
@@ -155,7 +155,7 @@ class Webhook
                         } else {
                             $messages[] = "Processing event \"stock_change\"";
                         }
-                    } elseif ($entity == "ShopProduct" && $this->configHelper->hasMode($storeId, Config::SYNC_PRODUCTS | Config::SYNC_ALL)) {
+                    } elseif ($entity == "ShopProduct" && $this->configHelper->hasMode($storeId, Config::SYNC_ORDERS | Config::SYNC_PRODUCTS | Config::SYNC_ALL)) {
                         $messages[] = "Processing entity \"ShopProduct\"";
                     } elseif ($entity == "Category" && $this->configHelper->hasMode($storeId, Config::SYNC_PRODUCTS | Config::SYNC_ALL)) {
                         $messages[] = "Processing entity \"Category\"";


### PR DESCRIPTION
 - Allowed processing of stock update messages during 'updated' product event for stores with active 'Orders only' stock config